### PR TITLE
Create a jar with all dependencies

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -1,0 +1,20 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>jar-with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+            <excludes>
+                <exclude>com.google.android:support-v4</exclude>
+            </excludes>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -9,20 +9,20 @@
 	<packaging>jar</packaging>
 	<dependencies>
 		<dependency>
-			<groupId>android</groupId>
+			<groupId>com.google.android</groupId>
 			<artifactId>android</artifactId>
-			<version>4.2_r1</version>
+			<version>4.1.1.4</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-		    <groupId>com.jakewharton</groupId>
-		    <artifactId>disklrucache</artifactId>
-		    <version>1.3.1</version>
+			<groupId>com.jakewharton</groupId>
+			<artifactId>disklrucache</artifactId>
+			<version>1.3.1</version>
 		</dependency>
 		<dependency>
-			<groupId>android.support</groupId>
-			<artifactId>compatibility-v4</artifactId>
-			<version>12</version>
+			<groupId>com.google.android</groupId>
+			<artifactId>support-v4</artifactId>
+			<version>r7</version>
 			<scope>compile</scope>
 		</dependency>
 		
@@ -43,7 +43,22 @@
 				</configuration>
 				<extensions>true</extensions>
 			</plugin>
-
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<descriptor>assembly.xml</descriptor>
+				</configuration>
+				<executions>
+					<execution>
+						<id>make-assembly</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Adds the maven assembly plugin in order to create a jar that contains all the dependencies, but excluding the android ones. 
