### PR TITLE
Don't add the android compatibility library to the assembled uber jar

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -13,7 +13,7 @@
             <unpack>true</unpack>
             <scope>runtime</scope>
             <excludes>
-                <exclude>com.google.android:support-v4</exclude>
+                <exclude>android.support:compatibility-v4</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
This fixes the maven assembly stuff. Now the jar-with-dependencies does not contain the compatibility library, since this is added by eclipse in most cases.
