### PR TITLE
Added support for customzing the data source of the downsample bitmap

### DIFF
--- a/src/com/qozix/mapview/MapView.java
+++ b/src/com/qozix/mapview/MapView.java
@@ -188,6 +188,17 @@ public class MapView extends ZoomPanLayout {
 		tileManager.setDecoder( decoder );
 	}
 	
+	/**
+	 * Sets a custom class to perform the decode operation when a downsample image is requested.
+	 * By default, a MapTileDecoder implementation is provided that renders bitmaps from the context's Assets,
+	 * but alternative implementations could be used that fetch images via HTTP, or from the SD card, or resources, SVG, etc.
+	 * {@link MapTileDecoderHttp} is an example of such an implementation.
+	 * @param decoder (MapTileDecoder) A class instance that implements MapTileDecoder, and must define a decode method, which accepts a String file name and a Context object, and returns a Bitmap
+	 */
+	public void setDownsampleDecoder( MapTileDecoder decoder ) {
+		downsampleManager.setDecoder( decoder );
+	}
+	
 	//------------------------------------------------------------------------------------
 	// Zoom Management API
 	//------------------------------------------------------------------------------------

--- a/src/com/qozix/mapview/viewmanagers/DownsampleManager.java
+++ b/src/com/qozix/mapview/viewmanagers/DownsampleManager.java
@@ -10,6 +10,9 @@ import android.graphics.drawable.BitmapDrawable;
 import android.util.Log;
 import android.view.View;
 
+import com.qozix.mapview.tiles.MapTileDecoder;
+import com.qozix.mapview.tiles.MapTileDecoderAssets;
+
 public class DownsampleManager {
 
 	private static final BitmapFactory.Options OPTIONS = new BitmapFactory.Options();
@@ -18,6 +21,13 @@ public class DownsampleManager {
 	}
 	
 	private String lastFileName;
+	private MapTileDecoder decoder = new MapTileDecoderAssets();
+	
+	public void setDecoder( MapTileDecoder d ){
+		if (d == null)
+			throw new IllegalArgumentException("d cannot be NULL.");
+		decoder = d;
+	}
 	
 	public void setDownsample( View view, String fileName ) {		
 		if ( fileName == null ) {
@@ -25,25 +35,22 @@ public class DownsampleManager {
 			lastFileName = null;
 			return;
 		}
+		// TODO: Maybe the tile decoder should decide this?
 		if ( fileName.equals( lastFileName )) {
 			return;
 		}		
 		lastFileName = fileName;
 		Context context = view.getContext();
-		AssetManager assets = context.getAssets();
+		
 		try {
-			InputStream input = assets.open( fileName );
-			if ( input != null ) {
-				try {
-					Bitmap bitmap = BitmapFactory.decodeStream( input, null, OPTIONS );
-					BitmapDrawable bitmapDrawable = new BitmapDrawable( bitmap );
-					view.setBackgroundDrawable( bitmapDrawable );
-				} catch( Exception e ) {
-					
-				}
+			Bitmap bitmap = decoder.decode(fileName, context);
+			
+			if (bitmap != null) {
+				BitmapDrawable bitmapDrawable = new BitmapDrawable( bitmap );
+				view.setBackgroundDrawable( bitmapDrawable );
 			}
 		} catch (Exception e ) {
-			
+			// TODO: Swallowing exceptions is not a good idea IMO
 		}
 	}
 }


### PR DESCRIPTION
I don't know if you were planing on adding this yourself, but I figured I might as well take a shot. 

The simplest and probably most consistent metod is to reuse MapTileDecoder for this purpose, using a "setDownsampeDecoder" method in MapView. It's a bit wierd for a tile decoder to be used in this manner, but it doesn't have any specific knowledge about tiles or zoom levels. Perhaps the interface really should have been called BitmapLoader or AssetLoader? 

In fact, it might have been better if the MapTileDecoder interface had been written like so:

``` java
public interface MapTileDecoder {
    public Bitmap decode(ZoomLevel level, int row, int column, 
                         Context context);
}
```

And then the default tile decoder would be a AssetTileDecoder that delegates to a AssetLoader with a signature similar to today's MapTileDecoder:

``` java
public class AssetTileDecoder implements MapTileDecoder {
    public AssetTileDecoder(AssetLoader loader) ...

    // Every %col% and %row% in the given path is processed as now
    public registerZoomLevel(ZoomLevel level, String path) ... 

    public Bitmap decode(ZoomLevel level, int row, int column, Context context) {
        String path = formatMap(getFormatFromLevel(level), row, column);
        return loader.decode(path, context);
    }
}

public interface AssetLoader {
    public Bitmap decode(String asset, Context context);
}
```

This rewritten MapTileDecoder would have been useful for me when I implemented a Tile Decoder that reads tiles directly from a large PNG file on disk (using BitmapRegionDecoder), but it's still possible currently - I just had to parse the string to get the zoom level, row and column index.
