### PR TITLE
Parallel decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,7 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+# IDEA
+*.iml
+.idea/

--- a/src/com/qozix/mapview/tiles/MapTileDecoderHttp.java
+++ b/src/com/qozix/mapview/tiles/MapTileDecoderHttp.java
@@ -1,5 +1,6 @@
 package com.qozix.mapview.tiles;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -38,15 +39,13 @@ public class MapTileDecoderHttp implements MapTileDecoder {
         InputStream input = null;
         try {
             connection = (HttpURLConnection) url.openConnection();
-            input = connection.getInputStream();
-            if (input != null) {
-                try {
-                    return BitmapFactory.decodeStream( input, null, OPTIONS );
-                } catch ( OutOfMemoryError oom ) {
-                    // oom - you can try sleeping (this method won't be called in the UI thread) or try again (or give up)
-                } catch ( Exception e ) {
-                    // unknown error decoding bitmap
-                }
+            input = new BufferedInputStream(connection.getInputStream());
+            try {
+                return BitmapFactory.decodeStream( input, null, OPTIONS );
+            } catch ( OutOfMemoryError oom ) {
+                // oom - you can try sleeping (this method won't be called in the UI thread) or try again (or give up)
+            } catch ( Exception e ) {
+                // unknown error decoding bitmap
             }
         } catch ( IOException e ) {
             Log.e(TAG, "Cannot download tile for URL: " + fileName, e);

--- a/src/com/qozix/mapview/tiles/TileRenderTask.java
+++ b/src/com/qozix/mapview/tiles/TileRenderTask.java
@@ -72,13 +72,17 @@ class TileRenderTask extends AsyncTask<Void, MapTile, Void> {
                             return null;
                         }
                         MapTile mapTile = params[0];
-                        //decode the map tile bitmap
+                        // decode the map tile bitmap
                         tileManager.decodeIndividualTile(mapTile);
                         return mapTile;
                     }
 
                     @Override
                     protected void onPostExecute(MapTile mapTile) {
+                        // stop if tile is null
+                        if (mapTile == null) {
+                            return;
+                        }
                         TileManager tileManager = reference.get();
                         if(tileManager != null) {
                             // if not cancelled render the tile
@@ -86,7 +90,7 @@ class TileRenderTask extends AsyncTask<Void, MapTile, Void> {
                                 tileManager.renderIndividualTile(mapTile);
                             }
 
-                            //when we have finished every render task, inform the manager
+                            // when we have finished every render task, inform the manager
                             if(numberOfTilesToRender.decrementAndGet() == 0) {
                                 tileManager.onRenderTaskPostExecute();
                             }
@@ -124,5 +128,4 @@ class TileRenderTask extends AsyncTask<Void, MapTile, Void> {
 			tileManager.onRenderTaskCancelled();
 		}
 	}
-
 }


### PR DESCRIPTION
While using the HTTP based tile decoder I had a lot of performance issues with the rendering of the tiles. The current implementation does the decoding of the tiles in one background thread and when all tiles have been decoded, the tiles are rendered on the UI thread.
This means that you have to wait for all tiles to load, which might take some time when using HTTP, until they are rendered. In this pull request I have introduced another way of decoding the tiles. There is still one background thread that is started for the list of tiles, but this background thread starts new threads for every tile and downloads/renderes them individually. The enclosing background thread only manages the individual threads and cancels them if needed.
For me this brings a lot of "visual" performance because every tile is now rendered directly after it was decoded and has not wait for the others.
